### PR TITLE
Fix receiving empty files (#174)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-wechat",
-  "version": "1.11.3",
+  "version": "1.11.5",
   "description": "Puppet WeChat for Wechaty",
   "type": "module",
   "exports": {

--- a/src/puppet-wechat.ts
+++ b/src/puppet-wechat.ts
@@ -72,6 +72,7 @@ import {
   WebMediaType,
   WebMessageMediaPayload,
   WebMessageRawPayload,
+  WebMessageStatus,
   WebMessageType,
   WebRoomRawMember,
   WebRoomRawPayload,
@@ -317,9 +318,16 @@ export class PuppetWeChat extends PUPPET.Puppet {
   }
 
   override async messageFile (messageId: string): Promise<FileBoxInterface> {
-    const rawPayload = await this.messageRawPayload(messageId)
-    const fileBox    = await this.messageRawPayloadToFile(rawPayload)
-    return fileBox
+    do {
+      const rawPayload = await this.messageRawPayload(messageId)
+      switch (rawPayload.MMStatus) {
+        case WebMessageStatus.SENDING:
+          await new Promise((resolve) => setTimeout(resolve, 50))
+          break
+        default:
+          return await this.messageRawPayloadToFile(rawPayload)
+      }
+    } while (true)
   }
 
   override async messageUrl (messageId: string)  : Promise<PUPPET.payloads.UrlLink> {

--- a/src/puppet-wechat.ts
+++ b/src/puppet-wechat.ts
@@ -317,8 +317,8 @@ export class PuppetWeChat extends PUPPET.Puppet {
   }
 
   override async messageFile (messageId: string): Promise<FileBoxInterface> {
-      const rawPayload = await this.messageRawPayload(messageId)
-      return await this.messageRawPayloadToFile(rawPayload)
+    const rawPayload = await this.messageRawPayload(messageId)
+    return await this.messageRawPayloadToFile(rawPayload)
   }
 
   override async messageUrl (messageId: string)  : Promise<PUPPET.payloads.UrlLink> {

--- a/src/puppet-wechat.ts
+++ b/src/puppet-wechat.ts
@@ -72,7 +72,6 @@ import {
   UploadMediaType,
   WebMessageMediaPayload,
   WebMessageRawPayload,
-  WebMessageStatus,
   WebMessageType,
   WebRoomRawMember,
   WebRoomRawPayload,
@@ -318,16 +317,8 @@ export class PuppetWeChat extends PUPPET.Puppet {
   }
 
   override async messageFile (messageId: string): Promise<FileBoxInterface> {
-    do {
       const rawPayload = await this.messageRawPayload(messageId)
-      switch (rawPayload.MMStatus) {
-        case WebMessageStatus.SENDING:
-          await new Promise((resolve) => setTimeout(resolve, 50))
-          break
-        default:
-          return await this.messageRawPayloadToFile(rawPayload)
-      }
-    } while (true)
+      return await this.messageRawPayloadToFile(rawPayload)
   }
 
   override async messageUrl (messageId: string)  : Promise<PUPPET.payloads.UrlLink> {

--- a/src/puppet-wechat.ts
+++ b/src/puppet-wechat.ts
@@ -318,7 +318,8 @@ export class PuppetWeChat extends PUPPET.Puppet {
 
   override async messageFile (messageId: string): Promise<FileBoxInterface> {
     const rawPayload = await this.messageRawPayload(messageId)
-    return await this.messageRawPayloadToFile(rawPayload)
+    const fileBox    = await this.messageRawPayloadToFile(rawPayload)
+    return fileBox
   }
 
   override async messageUrl (messageId: string)  : Promise<PUPPET.payloads.UrlLink> {

--- a/src/web-schemas.ts
+++ b/src/web-schemas.ts
@@ -157,7 +157,7 @@ export enum WebAppMsgType {
   READER_TYPE              = 100001,
 }
 /**
- * WebMessageSendStatus from webwx-app
+ * MsgSendStatus from webwx-app
  *  @see https://github.com/wechaty/webwx-app-tracker/blob/a12c78fb8bd7186c0f3bb0e18dd611151e6b8aac/formatted/webwxApp.js#L7520-L7524
  *
  *  //msg send status
@@ -166,7 +166,7 @@ export enum WebAppMsgType {
  *    MSG_SEND_STATUS_SUCC: 2
  *    MSG_SEND_STATUS_FAIL: 5
  */
-export enum WebMessageSendStatus{
+export enum MsgSendStatus{
     READY=0,
     SENDING=1,
     SUCCESS=2,
@@ -238,7 +238,7 @@ export interface WebMessageRawPayload {
    * Status-es
    */
   Status:           string,
-  MMStatus:         WebMessageSendStatus,  // img ng-show="message.MMStatus == 1" class="ico_loading"
+  MMStatus:         MsgSendStatus,  // img ng-show="message.MMStatus == 1" class="ico_loading"
                              // ng-click="resendMsg(message)" ng-show="message.MMStatus == 5" title="重新发送"
   MMFileStatus:     number,  // <p class="loading" ng-show="message.MMStatus == 1 || message.MMFileStatus == CONF.MM_SEND_FILE_STATUS_FAIL">
                              // CONF.MM_SEND_FILE_STATUS_QUEUED, MM_SEND_FILE_STATUS_SENDING

--- a/src/web-schemas.ts
+++ b/src/web-schemas.ts
@@ -156,7 +156,17 @@ export enum WebAppMsgType {
   RED_ENVELOPES            = 2001,
   READER_TYPE              = 100001,
 }
-export enum WebMessageStatus{
+/**
+ * WebMessageSendStatus from webwx-app
+ *  @see https://github.com/wechaty/webwx-app-tracker/blob/a12c78fb8bd7186c0f3bb0e18dd611151e6b8aac/formatted/webwxApp.js#L7520-L7524
+ *
+ *  //msg send status
+ *    MSG_SEND_STATUS_READY: 0
+ *    MSG_SEND_STATUS_SENDING: 1
+ *    MSG_SEND_STATUS_SUCC: 2
+ *    MSG_SEND_STATUS_FAIL: 5
+ */
+export enum WebMessageSendStatus{
     READY=0,
     SENDING=1,
     SUCCESS=2,
@@ -228,7 +238,7 @@ export interface WebMessageRawPayload {
    * Status-es
    */
   Status:           string,
-  MMStatus:         WebMessageStatus,  // img ng-show="message.MMStatus == 1" class="ico_loading"
+  MMStatus:         WebMessageSendStatus,  // img ng-show="message.MMStatus == 1" class="ico_loading"
                              // ng-click="resendMsg(message)" ng-show="message.MMStatus == 5" title="重新发送"
   MMFileStatus:     number,  // <p class="loading" ng-show="message.MMStatus == 1 || message.MMFileStatus == CONF.MM_SEND_FILE_STATUS_FAIL">
                              // CONF.MM_SEND_FILE_STATUS_QUEUED, MM_SEND_FILE_STATUS_SENDING

--- a/src/web-schemas.ts
+++ b/src/web-schemas.ts
@@ -156,7 +156,12 @@ export enum WebAppMsgType {
   RED_ENVELOPES            = 2001,
   READER_TYPE              = 100001,
 }
-
+export enum WebMessageStatus{
+    READY=0,
+    SENDING=1,
+    SUCCESS=2,
+    FAIL=5,
+}
 export interface WebMessageRawPayload {
   MsgId:            string,
 
@@ -223,7 +228,7 @@ export interface WebMessageRawPayload {
    * Status-es
    */
   Status:           string,
-  MMStatus:         number,  // img ng-show="message.MMStatus == 1" class="ico_loading"
+  MMStatus:         WebMessageStatus,  // img ng-show="message.MMStatus == 1" class="ico_loading"
                              // ng-click="resendMsg(message)" ng-show="message.MMStatus == 5" title="重新发送"
   MMFileStatus:     number,  // <p class="loading" ng-show="message.MMStatus == 1 || message.MMFileStatus == CONF.MM_SEND_FILE_STATUS_FAIL">
                              // CONF.MM_SEND_FILE_STATUS_QUEUED, MM_SEND_FILE_STATUS_SENDING

--- a/src/wechaty-bro.js
+++ b/src/wechaty-bro.js
@@ -428,7 +428,7 @@
       m.MMFileStatus = confFactory.MM_SEND_FILE_STATUS_SUCCESS
       m.MMStatus = confFactory.MSG_SEND_STATUS_SENDING
       m.sendByLocal = false
-
+      
       chatFactory.appendMessage(m)
       chatFactory.sendMessage(m)
     } catch (e) {
@@ -485,16 +485,31 @@
     return true
   }
 
-  function getMessage (id) {
+  async function getMessage (id) {
     const chatFactory = WechatyBro.glue.chatFactory
-    if (!chatFactory) {
-      log('chatFactory not inited')
+    const confFactory = WechatyBro.glue.confFactory
+    const rootScope = WechatyBro.glue.rootScope
+    if (!chatFactory||!rootScope||!confFactory) {
+      log('chatFactory,rootScope or confFactory not inited')
       return null
     }
     const msg = chatFactory.getMsg(id)
 
     if (!msg) {
       return null
+    }
+
+    if(msg.MMStatus==confFactory.MSG_SEND_STATUS_SENDING){
+      await new Promise((resolve)=>{
+        if(msg.MMStatus==confFactory.MSG_SEND_STATUS_SENDING){
+          const unwatch=rootScope.$watch(()=>msg.MMStatus,()=>{
+            unwatch();
+            resolve();
+          });
+        }else{
+          resolve();
+        }
+      })
     }
 
     const msgWithoutFunction = {}

--- a/src/wechaty-bro.js
+++ b/src/wechaty-bro.js
@@ -426,7 +426,7 @@
       const m = chatFactory.createMessage(d)
 
       m.MMFileStatus = confFactory.MM_SEND_FILE_STATUS_SUCCESS
-      m.MMStatus = confFactory.MSG_SEND_STATUS_SUCC
+      m.MMStatus = confFactory.MSG_SEND_STATUS_SENDING
       m.sendByLocal = false
 
       chatFactory.appendMessage(m)


### PR DESCRIPTION
Fix #174 
ref #180 
`MsgId` may change after `postMessage` succeeds, and the local `MsgId` is invalid in this case.
![image](https://user-images.githubusercontent.com/20336040/145789578-46245ee2-8a7f-4da1-96a1-33d2ae0abdde.png)

https://github.com/wechaty/puppet-wechat/blob/1442099e5cbf107d97f11e99f3dee2e793260aa8/src/puppet-wechat.ts#L1144