### PR TITLE
fix request error when image sending too fast

### DIFF
--- a/src/puppet-wechat.ts
+++ b/src/puppet-wechat.ts
@@ -75,6 +75,7 @@ import {
   WebMessageType,
   WebRoomRawMember,
   WebRoomRawPayload,
+  MsgSendStatus,
 }                           from './web-schemas.js'
 import { parseMentionIdList } from './pure-function-helpers/parse-mention-id-list.js'
 
@@ -1144,6 +1145,14 @@ export class PuppetWeChat extends PUPPET.Puppet {
     let url: undefined | string
 
     try {
+
+      if (rawPayload.MMStatus === MsgSendStatus.SENDING) {
+        throw new Error('message still sending')
+      }
+
+      if (rawPayload.MMStatus !== MsgSendStatus.SUCCESS) {
+        throw new Error('message was not sent successfully')
+      }
 
       switch (rawPayload.MsgType) {
         case WebMessageType.EMOTICON:

--- a/src/puppet-wechat.ts
+++ b/src/puppet-wechat.ts
@@ -1245,6 +1245,7 @@ export class PuppetWeChat extends PUPPET.Puppet {
 
     let mediatype: 'pic'|'video'|'doc'
     switch (msgType) {
+      // case WebMessageType.EMOTICON:  //gif cannot be "pic", it will cause sending wrong picture. #178
       case WebMessageType.IMAGE:
         mediatype = 'pic'
         break

--- a/src/web-schemas.ts
+++ b/src/web-schemas.ts
@@ -272,10 +272,10 @@ export interface WebMessageRawPayload {
 }
 
 export const enum WebMediaType {
-  Image      = 'pic',
-  Video      = 'video',
-  Attachment = 'doc',
-  // Audio      = 3, useless now
+  Image      = 1,
+  Video      = 2,
+  Audio      = 3,
+  Attachment = 4,
 }
 
 export interface WebRoomRawMember {

--- a/src/wechaty-bro.js
+++ b/src/wechaty-bro.js
@@ -501,14 +501,12 @@
 
     if(msg.MMStatus==confFactory.MSG_SEND_STATUS_SENDING){
       await new Promise((resolve)=>{
-        if(msg.MMStatus==confFactory.MSG_SEND_STATUS_SENDING){
-          const unwatch=rootScope.$watch(()=>msg.MMStatus,()=>{
+        const unwatch=rootScope.$watch(()=>msg.MMStatus,()=>{
+          if(msg.MMStatus!=confFactory.MSG_SEND_STATUS_SENDING){
             unwatch();
             resolve();
-          });
-        }else{
-          resolve();
-        }
+          }
+        });
       })
     }
 

--- a/src/wechaty-bro.js
+++ b/src/wechaty-bro.js
@@ -341,6 +341,8 @@
       throw new Error('getMsgImg() contentChatScope not found')
     }
     const path = contentChatScope.getMsgImg(id, type, message)
+    if(!path)
+      return null
     return window.location.origin + path
     // https://wx.qq.com/?&lang=en_US/cgi-bin/mmwebwx-bin/webwxgetmsgimg?&MsgID=4520385745174034093&skey=%40crypt_f9cec94b_a3aa5c868466d81bc518293eb292926e
     // https://wx.qq.com/cgi-bin/mmwebwx-bin/webwxgetmsgimg?&MsgID=8454987316459381112&skey=%40crypt_f9cec94b_bd210b2224f217afeab8d462af70cf53
@@ -359,6 +361,8 @@
       throw new Error('getMsgVideo() contentChatScope not found')
     }
     const path = contentChatScope.getMsgVideo(id)
+    if(!path)
+      return null
     return window.location.origin + path
   }
 

--- a/tests/puppeteer-attachment.spec.ts
+++ b/tests/puppeteer-attachment.spec.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env -S node --no-warnings --loader ts-node/esm
+/**
+ *   Wechaty - https://github.com/chatie/wechaty
+ *
+ *   @copyright 2016-2018 Huan LI <zixia@zixia.net>
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+import { test, sinon } from 'tstest'
+
+import { log } from '../src/config.js'
+
+import { PuppetWeChat } from '../src/puppet-wechat.js'
+import { WebMessageMediaPayload, WebMessageType } from '../src/web-schemas.js'
+import { FileBox } from 'wechaty-puppet/helper'
+import request from 'request'
+import { extname } from 'path'
+
+class PuppetTest extends PuppetWeChat {}
+
+test('Send Attachment', async (t) => {
+  const puppet = new PuppetTest()
+
+  const sandbox = sinon.createSandbox()
+  sandbox.stub(puppet.bridge, 'getCheckUploadUrl').returns(Promise.resolve('getCheckUploadUrl'))
+  sandbox.stub(puppet.bridge, 'getUploadMediaUrl').returns(Promise.resolve('getUploadMediaUrl'))
+  sandbox.stub(puppet.bridge, 'getBaseRequest').returns(Promise.resolve('{}'))
+  sandbox.stub(puppet.bridge, 'getPassticket').returns(Promise.resolve('getPassticket'))
+  sandbox.stub(puppet.bridge, 'cookies').returns(Promise.resolve([]))
+  sandbox.stub(puppet.bridge, 'hostname').returns(Promise.resolve('hostname'))
+  sandbox.replaceGetter(puppet, 'currentUserId', () => 'currentUserId')
+  const conversationId = 'filehelper'
+  const uploadMediaUrl = await puppet.bridge.getUploadMediaUrl()
+  const checkUploadUrl = await puppet.bridge.getCheckUploadUrl()
+  const mockedResCheckUpload = {
+    AESKey: 'AESKey',
+    Signature: 'Signature',
+  }
+  const mockedResUploadMedia = {
+    MediaId: 'MediaId',
+  }
+  const getExtName = (filename: string) => {
+    return extname(filename).slice(1)
+  }
+  const extToType = (ext: string): WebMessageType => {
+    switch (ext.toLowerCase()) {
+      case 'bmp':
+      case 'jpeg':
+      case 'jpg':
+      case 'png':
+        return WebMessageType.IMAGE
+      case 'gif':
+        return WebMessageType.EMOTICON
+      case 'mp4':
+        return WebMessageType.VIDEO
+      default:
+        return WebMessageType.APP
+    }
+  }
+  const mockSendMedia = async (msg: WebMessageMediaPayload) => {
+    log.silly('TestMessage', 'mocked bridge.sendMedia(%o)', msg)
+    const ext = getExtName(msg.FileName)
+    const msgType = extToType(ext)
+    t.match(msg.MMFileExt, /^\w+$/)
+    t.equal(msg.MsgType, msgType)
+    t.equal(msg.MMFileExt, ext)
+    return true
+  }
+  const mockPostRequest = (
+    options: request.RequiredUriUrl & request.CoreOptions,
+    callback?: request.RequestCallback,
+  ): request.Request => {
+    log.silly('TestMessage', 'mocked request.post(%o)', options)
+    let path: string | null = null
+    if ('url' in options) {
+      if (typeof options.url === 'object') {
+        path = options.url.path as string
+      } else {
+        path = options.url
+      }
+    } else if ('uri' in options) {
+      if (typeof options.uri === 'object') {
+        path = options.uri.path as string
+      } else {
+        path = options.uri
+      }
+    }
+    t.not(path, null)
+    if (path && callback) {
+      if (path.includes(uploadMediaUrl)) {
+        log.silly(
+          'TestMessage',
+          'requesting %s:%o',
+          uploadMediaUrl,
+          options.formData,
+        )
+        const formData = options.formData as {
+          name: string;
+          mediatype: string;
+          type: string;
+          uploadmediarequest: string;
+        }
+        const uploadmediarequest = JSON.parse(formData.uploadmediarequest) as {
+          AESKey: string;
+          BaseRequest: any;
+          ClientMediaId: number;
+          DataLen: number;
+          FileMd5: string;
+          FromUserName: string;
+          MediaType: number;
+          Signature: string;
+          StartPos: number;
+          ToUserName: string;
+          TotalLen: number;
+          UploadType: number;
+        }
+        const name = formData.name
+        const ext = getExtName(name)
+        let mediatype: string
+        switch (extToType(ext)) {
+          case WebMessageType.IMAGE:
+            mediatype = 'pic'
+            break
+          case WebMessageType.VIDEO:
+            mediatype = 'video'
+            break
+          default:
+            mediatype = 'doc'
+        }
+        t.equal(formData.mediatype, mediatype)
+        t.equal(uploadmediarequest.MediaType, 4)
+        t.equal(uploadmediarequest.UploadType, 2)
+
+        callback(null, {} as any, mockedResUploadMedia)
+      } else if (path.includes(checkUploadUrl)) {
+        callback(null, {} as any, mockedResCheckUpload)
+      } else {
+        log.silly('Unknown request:%s', path)
+      }
+    }
+    return null as any
+  }
+  sandbox.stub(puppet.bridge, 'sendMedia').callsFake(mockSendMedia)
+  sandbox.stub(request, 'post').callsFake(mockPostRequest)
+
+  await Promise.all(
+    [
+      'png',
+      'jpg',
+      'jpeg',
+      'bmp',
+      'gif',
+      'html',
+      'txt',
+      'docx',
+      'doc',
+      'xlsx',
+      'csv',
+      'mp3',
+      'mp4',
+      'mkv',
+    ].map(async (ext) => {
+      const giffile = FileBox.fromBuffer(Buffer.alloc(10), 'test.' + ext)
+      await puppet.messageSendFile(conversationId, giffile)
+    }),
+  )
+  sandbox.restore()
+})


### PR DESCRIPTION
Finally I figured out where `wx2.qq.comundefined` come from:
https://github.com/wechaty/puppet-wechat/blob/035e90461aa759b332056db9905bc5a9a4ac14e0/src/wechaty-bro.js#L332-L347
https://github.com/wechaty/webwx-app-tracker/blob/a12c78fb8bd7186c0f3bb0e18dd611151e6b8aac/formatted/webwxApp.js#L2100-L2106
some `getMsgImg` call returned `undefined` and `FileBox` requested the url.

If I send images one by one and save them, everything is fine, if I sending images too fast, an error will be occurred and crash the process when exception be passed to wechaty.
```log
Error: getaddrinfo ENOTFOUND wx2.qq.comundefined
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:71:26)
```

It should be fixed in #183, but I made a mistake, I thought `$watch` will works like Vue watch API, but it's not, the watch handler will be called immediately in first time even though `MMStatus` doesn't change.

#183 should always fail in my manual tests, but it does work, and it should not happen in #184 tests(I think the error cause by the default value of `MMStatus` change to 'SENDING' in #183), which is weird.

### Other Enhancements
1. I want to increase the priority of `file.mediaType` to ensure that user behavior is not overwritten
https://github.com/wechaty/puppet-wechat/blob/035e90461aa759b332056db9905bc5a9a4ac14e0/src/puppet-wechat.ts#L1245
```ts
const contentType = file.mediaType || mime.getType(ext)  || undefined
```

2. Can we add an error handler to catch exceptions from user listeners to ensure that process dose not crash?
```ts
import {WechatyBuilder} from "wechaty"
import {generate} from "qrcode-terminal"
const bot=WechatyBuilder.build({puppet:'wechaty-puppet-wechat'});
bot.on('scan',code=>generate(code,{small:true}));
bot.on('message',()=>{
    throw new Error('crash')
})
bot.start();
```