### PR TITLE
Fix fail to download message file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-wechat",
-  "version": "1.11.9",
+  "version": "1.11.10",
   "description": "Puppet WeChat for Wechaty",
   "type": "module",
   "exports": {

--- a/src/puppet-wechat.ts
+++ b/src/puppet-wechat.ts
@@ -328,14 +328,12 @@ export class PuppetWeChat extends PUPPET.Puppet {
   private async messageRawPayloadToFile (
     rawPayload: WebMessageRawPayload,
   ): Promise<FileBoxInterface> {
-    let url = await this.messageRawPayloadToUrl(rawPayload)
+    const url = await this.messageRawPayloadToUrl(rawPayload)
 
     if (!url) {
       throw new Error('no url for type ' + PUPPET.types.Message[rawPayload.MsgType])
     }
 
-    // use http instead of https, because https will only success on the very first request!
-    url = url.replace(/^https/i, 'http')
     const parsedUrl = new nodeUrl.URL(url)
 
     const msgFileName = messageFilename(rawPayload)


### PR DESCRIPTION
Ref to #194 
WeChat server now redirects the HTTP link to HTTPS, making the FileBox download file get 0 bytes returns.
e.g.
```
http://wx.qq.com/cgi-bin/mmwebwx-bin/webwxgetmsgimg
HTTP/1.1 302 Found
Connection: close
Date: Fri, 14-Jan-2022 09:09:03 GMT
Location: https://wx.qq.com/cgi-bin/mmwebwx-bin/webwxgetmsgimg?MsgID=xxx&skey=xxx
Content-Length: 0
```
I have not figured out why to replace HTTPS with HTTP [here](https://github.com/wechaty/puppet-wechat/blob/main/src/puppet-wechat.ts#L337) since I always download the file successfully through HTTPS.