### PR TITLE
Fix puppet save cookie error

### DIFF
--- a/src/puppet-wechat.ts
+++ b/src/puppet-wechat.ts
@@ -153,7 +153,7 @@ export class PuppetWeChat extends PUPPET.Puppet {
   }
 
   override async onStop (): Promise<void> {
-    log.verbose('PuppetWeChat', 'onSsop()')
+    log.verbose('PuppetWeChat', 'onStop()')
 
     /**
      * Clean listeners for `watchdog`

--- a/src/puppet-wechat.ts
+++ b/src/puppet-wechat.ts
@@ -1098,6 +1098,10 @@ export class PuppetWeChat extends PUPPET.Puppet {
   }
 
   async saveCookie (): Promise<void> {
+    if (this.state.inactive() === true) {
+      log.warn('PuppetWeChat', 'saveCookie() found state inactive, skipped.')
+      return
+    }
     const cookieList = await this.bridge.cookies()
     await this.memory.set(MEMORY_SLOT, cookieList)
     await this.memory.save()


### PR DESCRIPTION
In some scenarios `saveCookie` method will trigger when the puppet target is inactive that will cause the error [ProtocolError: Protocol error (Network.get cookies): Target closed.](https://github.com/wechaty/puppet-wechat/runs/4815868287?check_suite_focus=true)
This PR can make smoke testing happy :)