### PR TITLE
修复当uos设置为false时还是桌面登录

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1048,7 +1048,7 @@ export class Bridge extends EventEmitter {
     /**
      * `?target=t` is from https://github.com/wechaty/wechaty-puppet-wechat/pull/129
      */
-    const DEFAULT_URL = 'https://wx.qq.com?target=t'
+    const DEFAULT_URL = 'https://wx.qq.com'
 
     if (!cookieList || cookieList.length === 0) {
       log.silly('PuppetWeChatBridge', 'cookieDomain() no cookie, return default %s', DEFAULT_URL)
@@ -1080,7 +1080,7 @@ export class Bridge extends EventEmitter {
     }
     log.silly('PuppetWeChatBridge', 'cookieDomain() got %s', url)
 
-    return url + '?target=t'
+    return url
   }
 
   public async reload (): Promise<void> {


### PR DESCRIPTION
由于之前在其他地方也设置了`target=t`所以`uos:false`没有生效，现已修复