### PR TITLE
a PR about issue #230

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -252,7 +252,10 @@ export class Bridge extends EventEmitter {
     // set timeout 60000 ms，30000ms always timeout
     page.setDefaultTimeout(60000)
     // Does this related to(?) the CI Error: exception: Navigation Timeout Exceeded: 30000ms exceeded
-    await page.goto(url)
+    await page.goto(url, {
+      //The polling request on wx.qq.com prevents the page.goto() from reaching the 'load' state, so we use networkidle2 to wait for the page to be fully loaded.
+      waitUntil: 'networkidle2',
+    })
     log.verbose('PuppetWeChatBridge', 'initPage() after page.goto(url)')
 
     // await this.uosPatch(page)
@@ -263,7 +266,9 @@ export class Bridge extends EventEmitter {
       log.silly('PuppetWeChatBridge', 'initPage() page.setCookie() %s cookies set back', cookieList.length)
     }
 
-    page.on('load', () => this.emit('load', page))
+    //page.on('load', () => this.emit('load', page))
+    //due to polling request on wx.qq.com
+    page.on('domcontentloaded', () => this.emit('load', page))
     await page.reload() // reload page to make effect of the new cookie.
 
     return page


### PR DESCRIPTION
I am using wechaty on my Mac Pc and I run into the error below.

```
16:52:32 ERR PuppetWeChatBridge start() exception: TimeoutError: Navigation timeout of 60000 ms exceeded
16:52:32 SILL StateSwitch <PuppetWeChatBridge> inactive() is false
16:52:32 VERB StateSwitch <PuppetWeChatBridge> inactive(true) <- (false)
16:52:32 ERR PuppetWeChat initBridge() exception: Navigation timeout of 60000 ms exceeded
16:52:32 VERB PuppetWeChatBridge stop()
16:52:32 SILL StateSwitch <PuppetWeChatBridge> inactive() is true
16:52:32 VERB StateSwitch <PuppetWeChatBridge> inactive(pending) <- (true)
16:52:32 WARN PuppetWeChatBridge stop() page.close() exception: Error: Protocol error: Connection closed. Most likely the page has been closed.
16:52:32 SILL PuppetWeChatBridge stop() browser.close()-ed
16:52:32 SILL StateSwitch <PuppetWeChatBridge> inactive() is pending
16:52:32 VERB StateSwitch <PuppetWeChatBridge> inactive(true) <- (pending)
```
I have checked the issues and find https://github.com/wechaty/puppet-wechat/issues/230 has the same situation. So I analyzed the start process of this puppet, and I assume the polling request on wx.qq.com prevents the page.goto() from reaching the 'load' state. I tested myself by using puppeteer to open 'wx.qq.com' and the page cannot reach the state of 'load'.  
As a result, I tried to modify two parts of the code Bridge.ts about the waiting state of the Puppeteer.Page of opening the url 'wx.qq.com'. And it works.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix navigation timeout in `PuppetWeChatBridge` by using `networkidle2` and changing load event listener to `domcontentloaded` in `bridge.ts`.
> 
>   - **Behavior**:
>     - Fix navigation timeout in `initPage()` in `bridge.ts` by setting `waitUntil: 'networkidle2'` in `page.goto()`.
>     - Change page load event listener from `load` to `domcontentloaded` in `initPage()` to handle polling requests on `wx.qq.com`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wechaty%2Fpuppet-wechat&utm_source=github&utm_medium=referral)<sup> for 9e4df4f0f1a8ea5c9710e2078f1349c61486826d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved page loading behavior by ensuring navigation waits for the network to be idle.
	- Updated event listener to respond to the `domcontentloaded` event for better control during page initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->